### PR TITLE
event-chain with cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # event-emitter
 ## Environment agnostic event emitter
 
++ The Event Chain Supports 
+  + the event object as listener's "this" object. 
+  + return the result property of event object to emitter object. 
+  + prevent the rest of listener from be excuted if set the stopped property of event object to true 
+
+
 ### Installation
 
 	$ npm install event-emitter

--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ emitter.on('test', listener = function (args) {
 
 emitter.once('test', function (args) {
   // …invoked only once(!)
+  //and can return result to emit.
+  this.result = 18;
 });
 
-emitter.emit('test', arg1, arg2/*…args*/); // Two above listeners invoked
+//return the result is 18.
+var result = emitter.emit('test', arg1, arg2/*…args*/); // Two above listeners invoked
 emitter.emit('test', arg1, arg2/*…args*/); // Only first listener invoked
 
 emitter.off('test', listener);              // Removed first listener

--- a/index.js
+++ b/index.js
@@ -73,7 +73,14 @@ off = function (type, listener) {
 };
 
 emit = function (type) {
-	var i, l, listener, listeners, args;
+  function Event(target) {
+    this.target   = target;
+    this.stopped  = false;
+    this.result   = undefined;
+  }
+
+	var i, l, listener, listeners, args, evt;
+  evt = new Event(this);
 
 	if (!hasOwnProperty.call(this, '__ee__')) return;
 	listeners = this.__ee__[type];
@@ -86,18 +93,19 @@ emit = function (type) {
 
 		listeners = listeners.slice();
 		for (i = 0; (listener = listeners[i]); ++i) {
-			apply.call(listener, this, args);
+			apply.call(listener, evt, args);
+      if (evt.stopped) return evt.result;
 		}
 	} else {
 		switch (arguments.length) {
 		case 1:
-			call.call(listeners, this);
+			call.call(listeners, evt);
 			break;
 		case 2:
-			call.call(listeners, this, arguments[1]);
+			call.call(listeners, evt, arguments[1]);
 			break;
 		case 3:
-			call.call(listeners, this, arguments[1], arguments[2]);
+			call.call(listeners, evt, arguments[1], arguments[2]);
 			break;
 		default:
 			l = arguments.length;
@@ -105,9 +113,11 @@ emit = function (type) {
 			for (i = 1; i < l; ++i) {
 				args[i - 1] = arguments[i];
 			}
-			apply.call(listeners, this, args);
+			apply.call(listeners, evt, args);
+      break;
 		}
 	}
+  return evt.result;
 };
 
 methods = {

--- a/test/index.js
+++ b/test/index.js
@@ -2,13 +2,14 @@
 
 module.exports = function (t, a) {
 	var x = t(), y, count, count2, count3, count4, test, listener1, listener2;
-
+  var defaultEvent = {stopped:false, result: undefined};
 	x.emit('none');
 
 	test = "Once: ";
 	count = 0;
 	x.once('foo', function (a1, a2, a3) {
-		a(this, x, test + "Context");
+    defaultEvent.target = x;
+		a.deep(this, defaultEvent, test + "Context");
 		a.deep([a1, a2, a3], ['foo', x, 15], test + "Arguments");
 		++count;
 	});
@@ -23,13 +24,15 @@ module.exports = function (t, a) {
 	test = "On & Once: ";
 	count = 0;
 	x.on('foo', listener1 = function (a1, a2, a3) {
-		a(this, x, test + "Context");
+    defaultEvent.target = x;
+		a.deep(this, defaultEvent, test + "Context");
 		a.deep([a1, a2, a3], ['foo', x, 15], test + "Arguments");
 		++count;
 	});
 	count2 = 0;
 	x.once('foo', listener2 = function (a1, a2, a3) {
-		a(this, x, test + "Context");
+    defaultEvent.target = x;
+		a.deep(this, defaultEvent, test + "Context");
 		a.deep([a1, a2, a3], ['foo', x, 15], test + "Arguments");
 		++count2;
 	});
@@ -104,4 +107,28 @@ module.exports = function (t, a) {
 	a(count2, 2, test + "y on count");
 	a(count3, 1, test + "x once count");
 	a(count4, 1, test + "y once count");
+
+	test = "Event: ";
+	count = 0;
+	count2 = 0;
+	x.on('efoo', function () {
+		++count;
+    this.result = 129;
+	});
+	x.on('efoo', function () {
+		++count;
+	});
+	x.on('ebar', function () {
+		++count2;
+    this.result = "hiFirst"
+    this.stopped = true;
+	});
+	x.on('ebar', function () {
+		++count2;
+    this.result = "hiSec"
+	});
+	a(x.emit('efoo'), 129, test + 'foo result');
+	a(x.emit('ebar'), "hiFirst", test + 'bar result');
+	a(count, 2, test + "foo type");
+	a(count2, 1, test + "bar type");
 };

--- a/test/unify.js
+++ b/test/unify.js
@@ -16,7 +16,7 @@ module.exports = function (t) {
 			count2 = 0;
 			count3 = 0;
 			x.on('foo', function () { ++count; });
-			y.on('foo', function () { ++count2; });
+			y.on('foo', function () { ++count2; this.result=16});
 			z.on('foo', function () { ++count3; });
 
 			x.emit('foo');
@@ -26,7 +26,7 @@ module.exports = function (t) {
 
 			t(x, y);
 			a(x.__ee__, y.__ee__, "Post unify y");
-			x.emit('foo');
+			a(x.emit('foo'), 16, "unify(x,y): event foo result");
 			a(count, 2, "Post unify, x");
 			a(count2, 1, "Post unify, y");
 			a(count3, 0, "Post unify, z");


### PR DESCRIPTION
Add the event cache to improve performance and reduce memory usage.

```bash
the new with event cache:
➜  event-emitter git:(feature/event-chain) node benchmark/many-on.js
Emit for 3 listeners x1000000:

1:   582 EventEmitter2
2:   602 EventEmitter (Node.js native)
3:   851 event-emitter (this implementation)
4:  3355 Signals
➜  event-emitter git:(feature/event-chain) node benchmark/single-on.js
Emit for single listener x1000000:

1:   105 EventEmitter2
2:   122 EventEmitter (Node.js native)
3:   244 event-emitter (this implementation)
4:  3010 Signals
```
the old implementation (no cache) can not be endured:
```bash
Emit for single listener x1000000:

1:    94 EventEmitter2
2:   146 EventEmitter (Node.js native)
3:  2901 Signals
4: 11828 event-emitter (this implementation)
```