### PR TITLE
Clarify mixin support in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ emitter.emit('test', arg1, arg2/*…args*/); // Only first listener invoked
 emitter.off('test', listener);              // Removed first listener
 emitter.emit('test', arg1, arg2/*…args*/); // No listeners invoked
 ```
+
+Or as a mix-in:
+
+```javascript
+var ee = require('event-emitter');
+
+function MyClass() {
+  ee(this);
+}
+
+var obj = new MyClass();
+obj.on('test', function (args) {
+  // ... 
+});
+```
+
 ### Additional utilities
 
 #### allOff(obj) _(event-emitter/all-off)_


### PR DESCRIPTION
Use as a mix-in appears to be a supported mode of use, but it wasn't apparent to me until I read the
code. This adds a small example to the readme.

If this isn't an intended use-case, it would be good to understand how this package can be used as a
mix-in.